### PR TITLE
Add support for image gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+downloads
+download_log.dat
+.vscode


### PR DESCRIPTION
The script currently supports only post with a single image and not image galleries (with more than one post). I added support for that type of posts. I also changed the url to use new.json to keep a consistent ordering, my understanding is that before it was using "hot" ordering.

I made an assumption about the file extension in a gallery which i do not know if is correct but it works for my use case. I did not find an easy way to check for sure.

Added .gitignore to avoid committing .dat file and download folder accidentally.

First time writing perl so i imagine there are some optimizations to do...